### PR TITLE
Make running via file work in repl.

### DIFF
--- a/mini-repl/example
+++ b/mini-repl/example
@@ -1,0 +1,10 @@
+print "Give a number"; 
+var n : int;
+read n;
+var v : int := 1;
+var i : int;
+for i in 1..n do 
+   v := v * i;
+end for;
+print "The result is: ";
+print v; 


### PR DESCRIPTION
Can be ignored in the turn in, but allows to test running files.